### PR TITLE
Fix registering hooked native methods.

### DIFF
--- a/runtime/jni_internal.cc
+++ b/runtime/jni_internal.cc
@@ -2413,7 +2413,7 @@ class JNI {
             << c->GetDexCache()->GetLocation()->ToModifiedUtf8();
         ThrowNoSuchMethodError(soa, c, name, sig, "static or non-static");
         return JNI_ERR;
-      } else if (!m->IsNative()) {
+      } else if (!m->IsNative() && !(m->IsXposedHookedMethod() && m->GetXposedOriginalMethod()->IsNative())) {
         LOG(return_errors ? ERROR : FATAL) << "Failed to register non-native method "
             << PrettyDescriptor(c) << "." << name << sig
             << " as native";
@@ -2438,14 +2438,14 @@ class JNI {
     size_t unregistered_count = 0;
     for (size_t i = 0; i < c->NumDirectMethods(); ++i) {
       mirror::ArtMethod* m = c->GetDirectMethod(i);
-      if (m->IsNative()) {
+      if (m->IsNative() || (m->IsXposedHookedMethod() && m->GetXposedOriginalMethod()->IsNative())) {
         m->UnregisterNative(soa.Self());
         unregistered_count++;
       }
     }
     for (size_t i = 0; i < c->NumVirtualMethods(); ++i) {
       mirror::ArtMethod* m = c->GetVirtualMethod(i);
-      if (m->IsNative()) {
+      if (m->IsNative() || (m->IsXposedHookedMethod() && m->GetXposedOriginalMethod()->IsNative())) {
         m->UnregisterNative(soa.Self());
         unregistered_count++;
       }


### PR DESCRIPTION
This patch fixes a problem with native methods which are hooked by a module and registered through AndroidRuntime::registerNativeMethods.

The problem occurred when I was testing XPrivacy with a custom build of Xposed with the change to enable hooking of native methods. When I enabled XPrivacy, I got stuck in a bootloop (shortened logcat):

```
W/XPrivacy/XMediaRecorder( 1963): Native method=public native void android.media.MediaRecorder.start() throws java.lang.IllegalStateException
W/XPrivacy/XMediaRecorder( 1963): Native method=public native void android.media.MediaRecorder.stop() throws java.lang.IllegalStateException
....
E/art     ( 1963): Failed to register non-native method android.media.MediaRecorder.start()V as native
F/art     ( 1963): art/runtime/jni_internal.cc:769] JNI FatalError called: RegisterNatives failed for 'android/media/MediaRecorder'; aborting...
F/art     ( 1963): art/runtime/runtime.cc:290] Runtime aborting...
F/art     ( 1963): art/runtime/runtime.cc:290] Aborting thread:
F/art     ( 1963): art/runtime/runtime.cc:290] "main" prio=5 tid=1 Native
F/art     ( 1963): art/runtime/runtime.cc:290]   | group="" sCount=0 dsCount=0 obj=0x12c31100 self=0xb4827800
F/art     ( 1963): art/runtime/runtime.cc:290]   | sysTid=1963 nice=0 cgrp=default sched=0/0 handle=0xb6fb8bec
F/art     ( 1963): art/runtime/runtime.cc:290]   | state=R schedstat=( 1247655114 26798226 268 ) utm=111 stm=13 core=1 HZ=100
F/art     ( 1963): art/runtime/runtime.cc:290]   | stack=0xbe1d2000-0xbe1d4000 stackSize=8MB
F/art     ( 1963): art/runtime/runtime.cc:290]   | held mutexes= "abort lock" "mutator lock"(shared held)
F/art     ( 1963): art/runtime/runtime.cc:290]   native: #00 pc 0000484c  /system/lib/libbacktrace_libc++.so (UnwindCurrent::Unwind(unsigned int, ucontext*)+23)
```

The problem is that after XPrivacy hooked the method MediaRecorder.start(), the initialization of the MediaRouter JNI code calls AndroidRuntime::registerNativeMethods (see https://android.googlesource.com/platform/frameworks/base/+/android-5.1.0_r1/media/jni/android_media_MediaRecorder.cpp line 517), which will ultimately call RegisterNativeMethods inside jni_internal.cc.
Because the hooked native Xposed method does not have the native flag, the call fails. Adding a check whether the original method is native (see changeset) makes the problem disappear and the hooking successful (I am able to prevent the camera app from receiving an image through XPrivacy).

May be of interest for @M66B, as this fixes bootloops with XPrivacy.
A test version for Lollipop 5.1 on ARM including this patch is available at http://www.mediafire.com/download/ni4p461civf6csz/xposed-sdk22-arm-20150628.zip
