### PR TITLE
runtime: arm64: add cortex-a53.a57 to the known CPUs list

### DIFF
--- a/runtime/arch/arm64/instruction_set_features_arm64.cc
+++ b/runtime/arch/arm64/instruction_set_features_arm64.cc
@@ -30,7 +30,7 @@ const Arm64InstructionSetFeatures* Arm64InstructionSetFeatures::FromVariant(
 
   // Look for variants that need a fix for a53 erratum 835769.
   static const char* arm64_variants_with_a53_835769_bug[] = {
-      "default", "generic", "cortex-a53"  // Pessimistically assume all generic ARM64s are A53s.
+      "default", "generic", "cortex-a53", "cortex-a53.a57"  // Pessimistically assume all generic ARM64s are A53s.
   };
   bool needs_a53_835769_fix = FindVariantInArray(arm64_variants_with_a53_835769_bug,
                                                  arraysize(arm64_variants_with_a53_835769_bug),


### PR DESCRIPTION
- We may want to tune for the big.LITTLE combiation consisting of cortex-a53 and cortex-a57 cores
- As cortex-a53 cores are present, we are applying the needed arm errata fixes
- If we set this combination as TARGET_CPU and this patch is not present, ART will completely fail dexopt at runtime

Change-Id: I3b6a58c22706c2b272810833895c29768ce76081
Signed-off-by: Alex Naidis alex.naidis@linux.com
